### PR TITLE
test: app 시작시 test용 SUPER_ADMIN 추가 구현

### DIFF
--- a/src/main/java/sparta/spartateamproject1/dev/TestSuperAdminAdder.java
+++ b/src/main/java/sparta/spartateamproject1/dev/TestSuperAdminAdder.java
@@ -1,0 +1,49 @@
+package sparta.spartateamproject1.dev;
+
+import java.time.LocalDateTime;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import sparta.spartateamproject1.config.PasswordEncoder;
+import sparta.spartateamproject1.entity.Admin;
+import sparta.spartateamproject1.entity.ApprovalResult;
+import sparta.spartateamproject1.repository.AdminRepository;
+import sparta.spartateamproject1.type.AdminStatus;
+import sparta.spartateamproject1.type.Role;
+
+@Component
+@ConditionalOnProperty(
+    name = "app.add-test-super-admin",
+    havingValue = "true",
+    matchIfMissing = false
+)
+@RequiredArgsConstructor
+public class TestSuperAdminAdder implements CommandLineRunner {
+    
+    private final AdminRepository adminRepository;
+
+    private final PasswordEncoder passwordEncoder;
+    
+    @Override
+    public void run(String... args) throws Exception {
+        ApprovalResult result = new ApprovalResult();
+        result.setApprovedAt(LocalDateTime.now());
+        result.setIsApproved(true);
+
+        Admin superAdmin = Admin.builder()
+            .name("super")
+            .email("super@gmail.com")
+            .password(passwordEncoder.encode("super1234"))
+            .phoneNumber("010-1111-2222")
+            .role(Role.SUPER_ADMIN)
+            .status(AdminStatus.ACTIVE)
+            .approvalResult(result)
+            .build();
+
+        adminRepository.save(superAdmin);
+    }
+}


### PR DESCRIPTION
SUPER_ADMIN이 없어 테스트를 하기가 어려웠습니다.

app이 돌아가는 와중에 database에 들어가 직접 주입하는 방식도 고려해
보았지만 그럴경우 BCrypt가 hashing한 패스워드에 맞춰 주입하기가
어렵습니다.

그렇기 때문에 TestSuperAdminAdder라는 클래스를 만들어 app 시작시
SUPER_ADMIN을 추가하는 방식이 맞다고 생각합니다.

properties 파일에

app.add-test-super-admin=true

로 설정 시에만 적용되기에 안전하다 생각합니다.