### PR TITLE
feat: 관리자 상태변경, 역할변경, 비밀번호변경 추가, fix: 슈퍼관리자 삭제 불가 수정

### DIFF
--- a/src/main/java/sparta/spartateamproject1/controller/AdminController.java
+++ b/src/main/java/sparta/spartateamproject1/controller/AdminController.java
@@ -86,8 +86,26 @@ public class AdminController {
     public ResponseEntity<AdminUpdateDto.Response> update(
             @SessionAttribute(name = "adminSession") LoginSessionAttribute loginSessionAttribute,
             @PathVariable Long adminId,
-            @RequestBody AdminUpdateDto.Request request) {
+            @Valid @RequestBody AdminUpdateDto.Request request) {
         return ResponseEntity.status(HttpStatus.OK).body(adminService.update(loginSessionAttribute.getId(), adminId, request));
+    }
+
+    //관리자 역할 변경
+    @PatchMapping("/admins/{adminId}/role")
+    public ResponseEntity<AdminUpdateDto.RoleResponse> updateRole(
+            @SessionAttribute(name = "adminSession") LoginSessionAttribute loginSessionAttribute,
+            @PathVariable Long adminId,
+            @Valid @RequestBody AdminUpdateDto.RoleRequest request) {
+        return ResponseEntity.status(HttpStatus.OK).body(adminService.updateRole(loginSessionAttribute.getId(), adminId, request));
+    }
+
+    //관리자 상태 변경
+    @PatchMapping("/admins/{adminId}/status")
+    public ResponseEntity<AdminUpdateDto.StatusResponse> updateStatus(
+            @SessionAttribute(name = "adminSession") LoginSessionAttribute loginSessionAttribute,
+            @PathVariable Long adminId,
+            @Valid @RequestBody AdminUpdateDto.StatusRequest request) {
+        return ResponseEntity.status(HttpStatus.OK).body(adminService.updateStatus(loginSessionAttribute.getId(), adminId, request));
     }
 
 
@@ -109,7 +127,7 @@ public class AdminController {
         return ResponseEntity.status(HttpStatus.OK).body(adminService.approve(loginSessionAttribute.getId(), adminId));
     }
 
-    //관리자 신청 거절
+    //관리자 신청 거부
     //adminId: 거절할 관리자
     @PostMapping("/admins/{adminId}/deny")
     public ResponseEntity<AdminDeniedDto.DeniedResponse> denied(
@@ -128,5 +146,14 @@ public class AdminController {
     }
 
     //관리자 자신 비밀번호 변경
+    @PatchMapping("/admins/{adminId}/password")
+    public ResponseEntity<AdminUpdateDto.PasswordResponse> updatePassword(
+            @SessionAttribute(name = "adminSession") LoginSessionAttribute loginSessionAttribute,
+            @PathVariable Long adminId,
+            @RequestBody AdminUpdateDto.PasswordRequest request
+    ) {
+        return ResponseEntity.status(HttpStatus.OK).body(adminService.updatePassword(loginSessionAttribute.getId(), adminId, request));
+
+    }
 
 }

--- a/src/main/java/sparta/spartateamproject1/controller/AdminController.java
+++ b/src/main/java/sparta/spartateamproject1/controller/AdminController.java
@@ -145,7 +145,7 @@ public class AdminController {
         return ResponseEntity.status(HttpStatus.OK).body(adminService.updateSelf(loginSessionAttribute.getId(), request));
     }
 
-    //관리자 자신 비밀번호 변경
+    //관리자 비밀번호 변경
     @PatchMapping("/admins/{adminId}/password")
     public ResponseEntity<AdminUpdateDto.PasswordResponse> updatePassword(
             @SessionAttribute(name = "adminSession") LoginSessionAttribute loginSessionAttribute,

--- a/src/main/java/sparta/spartateamproject1/dto/AdminUpdateDto.java
+++ b/src/main/java/sparta/spartateamproject1/dto/AdminUpdateDto.java
@@ -106,8 +106,15 @@ public class AdminUpdateDto {
     }
 
     @Getter
+    @Builder
     public static class PasswordResponse {
-        private String message;
+        private final String message;
+
+        public static AdminUpdateDto.PasswordResponse success(String message){
+            return AdminUpdateDto.PasswordResponse.builder()
+                    .message(message)
+                    .build();
+        }
     }
 
 }

--- a/src/main/java/sparta/spartateamproject1/dto/AdminUpdateDto.java
+++ b/src/main/java/sparta/spartateamproject1/dto/AdminUpdateDto.java
@@ -2,12 +2,13 @@ package sparta.spartateamproject1.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 import sparta.spartateamproject1.entity.Admin;
+import sparta.spartateamproject1.type.AdminStatus;
+import sparta.spartateamproject1.type.Role;
 
 @Getter
 public class AdminUpdateDto {
@@ -40,6 +41,73 @@ public class AdminUpdateDto {
                     .build();
         }
 
+    }
+
+    @Getter
+    public static class RoleRequest {
+        @NotNull(message = "역할을 설정해주세요.")
+        private Role role;
+    }
+
+
+    @Getter
+    @Builder
+    public static class RoleResponse {
+        private final Long id;
+        private final String name;
+        private final String email;
+        private final Role role;
+        private final AdminStatus status;
+
+        public static AdminUpdateDto.RoleResponse fromEntity(Admin admin){
+            return AdminUpdateDto.RoleResponse.builder()
+                    .id(admin.getId())
+                    .name(admin.getName())
+                    .email(admin.getEmail())
+                    .role(admin.getRole())
+                    .status(admin.getStatus())
+                    .build();
+        }
 
     }
+
+    @Getter
+    public static class StatusRequest {
+        @NotNull(message = "상태를 설정해주세요.")
+        private AdminStatus status;
+    }
+
+
+    @Getter
+    @Builder
+    public static class StatusResponse {
+        private final Long id;
+        private final String name;
+        private final String email;
+        private final Role role;
+        private final AdminStatus status;
+
+        public static AdminUpdateDto.StatusResponse fromEntity(Admin admin){
+            return AdminUpdateDto.StatusResponse.builder()
+                    .id(admin.getId())
+                    .name(admin.getName())
+                    .email(admin.getEmail())
+                    .role(admin.getRole())
+                    .status(admin.getStatus())
+                    .build();
+        }
+
+    }
+
+    @Getter
+    public static class PasswordRequest {
+        private String oldPassword;
+        private String newPassword;
+    }
+
+    @Getter
+    public static class PasswordResponse {
+        private String message;
+    }
+
 }

--- a/src/main/java/sparta/spartateamproject1/entity/Admin.java
+++ b/src/main/java/sparta/spartateamproject1/entity/Admin.java
@@ -50,10 +50,18 @@ public class Admin {
     @Embedded
     private ApprovalResult approvalResult;
 
-    public void updateAdmin(String name, String email, String phoneNumber){
+    public void updateAdmin(String name, String email, String phoneNumber) {
         this.name = name;
         this.email = email;
         this.phoneNumber = phoneNumber;
+    }
+
+    public void updatePassword(String password){
+        this.password = password;
+    }
+
+    public void updateRole(Role role){
+        this.role = role;
     }
 
     public void updateStatus(AdminStatus status){

--- a/src/main/java/sparta/spartateamproject1/exception/GlobalExceptionHandler.java
+++ b/src/main/java/sparta/spartateamproject1/exception/GlobalExceptionHandler.java
@@ -42,4 +42,14 @@ public class GlobalExceptionHandler {
     public ResponseEntity<?> handleAdminNotFoundException(AdminNotFoundException e) {
         return ResponseEntity.badRequest().body(e.getMessage());
     }
+
+    @ExceptionHandler(SamePasswordException.class)
+    public ResponseEntity<?> handleSamePasswordException(SamePasswordException e) {
+        return ResponseEntity.badRequest().body(e.getMessage());
+    }
+
+    @ExceptionHandler(InvalidPasswordException.class)
+    public ResponseEntity<?> handleInvalidPasswordException(InvalidPasswordException e) {
+        return ResponseEntity.badRequest().body(e.getMessage());
+    }
 }

--- a/src/main/java/sparta/spartateamproject1/exception/GlobalExceptionHandler.java
+++ b/src/main/java/sparta/spartateamproject1/exception/GlobalExceptionHandler.java
@@ -48,5 +48,14 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
     }
 
+    @ExceptionHandler(SamePasswordException.class)
+    public ResponseEntity<?> handleSamePasswordException(SamePasswordException e) {
+        return ResponseEntity.badRequest().body(e.getMessage());
+    }
+
+    @ExceptionHandler(InvalidPasswordException.class)
+    public ResponseEntity<?> handleInvalidPasswordException(InvalidPasswordException e) {
+        return ResponseEntity.badRequest().body(e.getMessage());
+    }
 
 }

--- a/src/main/java/sparta/spartateamproject1/exception/InvalidPasswordException.java
+++ b/src/main/java/sparta/spartateamproject1/exception/InvalidPasswordException.java
@@ -1,0 +1,7 @@
+package sparta.spartateamproject1.exception;
+
+public class InvalidPasswordException extends RuntimeException{
+    public InvalidPasswordException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/sparta/spartateamproject1/exception/SamePasswordException.java
+++ b/src/main/java/sparta/spartateamproject1/exception/SamePasswordException.java
@@ -1,0 +1,8 @@
+package sparta.spartateamproject1.exception;
+
+public class SamePasswordException extends RuntimeException{
+
+    public SamePasswordException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/sparta/spartateamproject1/service/AdminService.java
+++ b/src/main/java/sparta/spartateamproject1/service/AdminService.java
@@ -27,4 +27,10 @@ public interface AdminService {
     AdminDeniedDto.DeniedResponse denied(Long id, Long adminId, AdminDeniedDto.DeniedRequest request);
 
     UpdateSelfDto.Response updateSelf(Long id, UpdateSelfDto.Request request);
+
+    AdminUpdateDto.RoleResponse updateRole(Long id, Long adminId, AdminUpdateDto.RoleRequest request);
+
+    AdminUpdateDto.StatusResponse updateStatus(Long id, Long adminId, AdminUpdateDto.StatusRequest request);
+
+    AdminUpdateDto.PasswordResponse updatePassword(Long id, Long adminId, AdminUpdateDto.PasswordRequest request);
 }

--- a/src/main/java/sparta/spartateamproject1/service/impl/AdminServiceImpl.java
+++ b/src/main/java/sparta/spartateamproject1/service/impl/AdminServiceImpl.java
@@ -119,23 +119,61 @@ public class AdminServiceImpl implements AdminService {
     //id 는 슈퍼관리자의 아이디
     //adminId 는 수정할 관리자의 아이디
     public AdminUpdateDto.Response update(Long id, Long adminId, AdminUpdateDto.Request request) {
-        //슈퍼관리자 또는 자기자신인지 확인
+        //슈퍼관리자인지 확인
         Admin admin = adminRepository.findById(adminId).orElseThrow(() -> new AdminNotFoundException("존재하지 않는 관리자입니다."));
 
         admin.updateAdmin(request.getName(), request.getEmail(), request.getPhoneNumber());
         return AdminUpdateDto.Response.fromEntity(admin);
     }
 
+    //관리자 역할 변경
+    //id 는 슈퍼관리자의 아이디
+    //adminId 는 수정할 관리자의 아이디
+    @Override
+    public AdminUpdateDto.RoleResponse updateRole(Long id, Long adminId, AdminUpdateDto.RoleRequest request) {
+        //슈퍼관리자인지 확인
+        Admin superAdmin = checkSuperAdmin(id);
+        Admin admin = adminRepository.findById(adminId).orElseThrow(() -> new AdminNotFoundException("존재하지 않는 관리자입니다."));
+
+        System.out.println("===================admin.getEmail() = " + admin.getEmail());
+
+        admin.updateRole(request.getRole());
+
+        System.out.println("===================admin.getEmail() = " + admin.getEmail());
+        return AdminUpdateDto.RoleResponse.fromEntity(admin);
+    }
+
+    //관리자 상태 변경
+    //id 는 슈퍼관리자의 아이디
+    //adminId 는 수정할 관리자의 아이디
+    @Override
+    @Transactional
+    public AdminUpdateDto.StatusResponse updateStatus(Long id, Long adminId, AdminUpdateDto.StatusRequest request) {
+        //슈퍼관리자인지 확인
+        Admin superAdmin = checkSuperAdmin(id);
+        Admin admin = adminRepository.findById(adminId).orElseThrow(() -> new AdminNotFoundException("존재하지 않는 관리자입니다."));
+
+        admin.updateStatus(request.getStatus());
+        return AdminUpdateDto.StatusResponse.fromEntity(admin);
+    }
+
+    @Override
+    public AdminUpdateDto.PasswordResponse updatePassword(Long id, Long adminId, AdminUpdateDto.PasswordRequest request) {
+        return null;
+    }
+
+
+    //관리자 삭제
     @Override
     @Transactional
     //id 는 슈퍼관리자의 아이디
     //adminId 는 삭제할 관리자의 아이디
     public void delete(Long id, Long adminId) {
         //이 아이디가 슈퍼관리자인지 확인
-        Admin admin = checkSuperAdmin(id);
-        boolean exists = adminRepository.existsById(adminId);
-        if(!exists) {
-            throw new AdminNotFoundException("존재하지 않는 관리자입니다.");
+        Admin superAdmin = checkSuperAdmin(id);
+        Admin admin = adminRepository.findById(adminId).orElseThrow(() -> new AdminNotFoundException("존재하지 않는 관리자입니다."));
+        if(admin.getRole().equals(Role.SUPER_ADMIN)){
+            throw new ForbiddenException("슈퍼관리자는 삭제할 수 없습니다.");
         }
         adminRepository.deleteById(adminId);
     }
@@ -187,6 +225,10 @@ public class AdminServiceImpl implements AdminService {
 
         return UpdateSelfDto.Response.fromEntity(admin);
     }
+
+    //관리자 자신의 비밀번호 변경
+
+
 
     //이 아이디가 슈퍼관리자인지 확인 후 권한이 없다면 throw
     public Admin checkSuperAdmin(Long id) {

--- a/src/main/java/sparta/spartateamproject1/service/impl/AdminServiceImpl.java
+++ b/src/main/java/sparta/spartateamproject1/service/impl/AdminServiceImpl.java
@@ -130,6 +130,7 @@ public class AdminServiceImpl implements AdminService {
     //id 는 슈퍼관리자의 아이디
     //adminId 는 수정할 관리자의 아이디
     @Override
+    @Transactional
     public AdminUpdateDto.RoleResponse updateRole(Long id, Long adminId, AdminUpdateDto.RoleRequest request) {
         //슈퍼관리자인지 확인
         Admin superAdmin = checkSuperAdmin(id);
@@ -217,7 +218,7 @@ public class AdminServiceImpl implements AdminService {
         return UpdateSelfDto.Response.fromEntity(admin);
     }
 
-    //관리자 비밀번호 변경
+    //관리자 비밀번호 변경 - 자기자신만 가능
     //id 는 비밀번호 변경을 요청한 관리자의 아이디
     //adminId 는 비밀번호가 바뀔 관리자의 아이디
     @Override
@@ -226,9 +227,9 @@ public class AdminServiceImpl implements AdminService {
 
         Admin requestAdmin = adminRepository.findById(id).orElseThrow(()-> new AdminNotFoundException("존재하지 않는 관리자입니다."));
         Admin targetAdmin = adminRepository.findById(adminId).orElseThrow(()-> new AdminNotFoundException("존재하지 않는 관리자입니다."));
-        //요청자가 슈퍼관리자 또는 자기자신인지 확인
-        //요청자가 슈퍼관리자도 아니고 자기자신도 아니라면 오류발생
-        if(! requestAdmin.getRole().equals(Role.SUPER_ADMIN) && !id.equals(adminId)){
+        //요청자가 자기자신인지 확인
+        //요청자가 자기자신 아니라면 오류발생
+        if(!id.equals(adminId)){
             throw new ForbiddenException("권한이 없습니다.");
         }
         //현재 비밀번호가 맞는지 확인 후 맞으면 수정, 틀리면 오류

--- a/src/main/java/sparta/spartateamproject1/service/impl/AdminServiceImpl.java
+++ b/src/main/java/sparta/spartateamproject1/service/impl/AdminServiceImpl.java
@@ -157,11 +157,6 @@ public class AdminServiceImpl implements AdminService {
         return AdminUpdateDto.StatusResponse.fromEntity(admin);
     }
 
-    @Override
-    public AdminUpdateDto.PasswordResponse updatePassword(Long id, Long adminId, AdminUpdateDto.PasswordRequest request) {
-        return null;
-    }
-
 
     //관리자 삭제
     @Override
@@ -226,7 +221,34 @@ public class AdminServiceImpl implements AdminService {
         return UpdateSelfDto.Response.fromEntity(admin);
     }
 
-    //관리자 자신의 비밀번호 변경
+    //관리자 비밀번호 변경
+    //id 는 비밀번호 변경을 요청한 관리자의 아이디
+    //adminId 는 비밀번호가 바뀔 관리자의 아이디
+    @Override
+    @Transactional
+    public AdminUpdateDto.PasswordResponse updatePassword(Long id, Long adminId, AdminUpdateDto.PasswordRequest request) {
+
+        Admin requestAdmin = adminRepository.findById(id).orElseThrow(()-> new AdminNotFoundException("존재하지 않는 관리자입니다."));
+        Admin targetAdmin = adminRepository.findById(adminId).orElseThrow(()-> new AdminNotFoundException("존재하지 않는 관리자입니다."));
+        //요청자가 슈퍼관리자 또는 자기자신인지 확인
+        //요청자가 슈퍼관리자도 아니고 자기자신도 아니라면 오류발생
+        if(! requestAdmin.getRole().equals(Role.SUPER_ADMIN) && !id.equals(adminId)){
+            throw new ForbiddenException("권한이 없습니다.");
+        }
+        //현재 비밀번호가 맞는지 확인 후 맞으면 수정, 틀리면 오류
+        if(!passwordEncoder.matches(request.getOldPassword(), targetAdmin.getPassword())) {
+            throw new InvalidPasswordException("비밀번호가 다릅니다.");
+        }
+
+        //바꿀 비밀번호와 현재 비밀번호가 같다면 오류
+        if(passwordEncoder.matches(request.getNewPassword(), targetAdmin.getPassword())) {
+            throw new SamePasswordException("동일한 비밀번호로 바꿀 수 없습니다.");
+        }
+        String password = passwordEncoder.encode(request.getNewPassword());
+        targetAdmin.updatePassword(password);
+
+        return AdminUpdateDto.PasswordResponse.success("비밀번호 변경이 완료되었습니다.");
+    }
 
 
 

--- a/src/main/java/sparta/spartateamproject1/service/impl/AdminServiceImpl.java
+++ b/src/main/java/sparta/spartateamproject1/service/impl/AdminServiceImpl.java
@@ -134,12 +134,8 @@ public class AdminServiceImpl implements AdminService {
         //슈퍼관리자인지 확인
         Admin superAdmin = checkSuperAdmin(id);
         Admin admin = adminRepository.findById(adminId).orElseThrow(() -> new AdminNotFoundException("존재하지 않는 관리자입니다."));
-
-        System.out.println("===================admin.getEmail() = " + admin.getEmail());
-
         admin.updateRole(request.getRole());
 
-        System.out.println("===================admin.getEmail() = " + admin.getEmail());
         return AdminUpdateDto.RoleResponse.fromEntity(admin);
     }
 


### PR DESCRIPTION
AdminUpdateDto 에 상태변경, 역할변경, 비밀번호 변경 관련 dto 추가
admin 엔티티에 상태변경, 역할변경, 비밀번호변경 함수 추가
전역 예외처리에 동일한 비밀번호로 변경하는 에러, 현재비밀번호확인실패 에러 추가
컨트롤러 및 서비스에 상태변경, 역할변경, 비밀번호변경 추가
관리자 삭제에서 슈퍼관리자 삭제 불가 로직 추가
