### PR TITLE
feat: null의 상품 등록 관리자를 허용

### DIFF
--- a/src/main/java/sparta/spartateamproject1/dev/TestItemAdder.java
+++ b/src/main/java/sparta/spartateamproject1/dev/TestItemAdder.java
@@ -61,7 +61,7 @@ public class TestItemAdder implements CommandLineRunner {
                     .email(adminEmails.get(i))
                     .password(passwordEncoder.encode("12345678"))
                     .phoneNumber(adminPhoneNumbers.get(i))
-                    .role(Role.SUPER_ADMIN) // 일단은 전부 슈퍼 유저로
+                    .role(Role.ADMIN) // 일단은 전부 슈퍼 유저로
                     .status(AdminStatus.ACTIVE)
                     .approvalResult(result)
                     .build();

--- a/src/main/java/sparta/spartateamproject1/dev/TestItemAdder.java
+++ b/src/main/java/sparta/spartateamproject1/dev/TestItemAdder.java
@@ -71,6 +71,9 @@ public class TestItemAdder implements CommandLineRunner {
             admins.add(admin);
         }
 
+        // 상품의 등록관리자가 삭제되어 null 일수도 있습니다.
+        admins.add(null);
+
         // 테스트 상품 추가
         ItemCategory[] categories = ItemCategory.values();
         ItemStatus[] statuses = ItemStatus.values();

--- a/src/main/java/sparta/spartateamproject1/dto/ItemGetDto.java
+++ b/src/main/java/sparta/spartateamproject1/dto/ItemGetDto.java
@@ -4,10 +4,12 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import sparta.spartateamproject1.entity.Item;
+import sparta.spartateamproject1.entity.Admin;
 import sparta.spartateamproject1.type.ItemStatus;
 import sparta.spartateamproject1.type.ItemCategory;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 public class ItemGetDto {
     @Getter
@@ -21,18 +23,32 @@ public class ItemGetDto {
         private final Long stock;
         private final ItemStatus status;
         private final LocalDateTime createdAt;
-        private final Long adminId;
 
-        public static ItemGetDto.Response fromEntity(Item item){
+        private final String adminName;
+        private final String adminEmail;
+
+        public static ItemGetDto.Response fromEntity(Item item, Optional<Admin> admin){
+            String adminName = null;
+            String adminEmail = null;
+
+            if (admin.isPresent()) {
+                adminName = admin.get().getName();
+                adminEmail = admin.get().getEmail();
+            }
+
             return ItemGetDto.Response.builder()
                     .id(item.getId())
+
                     .name(item.getName())
                     .category(item.getCategory())
                     .price(item.getPrice())
                     .stock(item.getStock())
                     .status(item.getStatus())
                     .createdAt(item.getCreatedAt())
-                    .adminId(item.getAdmin().getId())
+
+                    .adminName(adminName)
+                    .adminEmail(adminEmail)
+
                     .build();
         }
     }

--- a/src/main/java/sparta/spartateamproject1/entity/Item.java
+++ b/src/main/java/sparta/spartateamproject1/entity/Item.java
@@ -46,8 +46,10 @@ public class Item {
     private LocalDateTime modifiedAt;
 
 
+    // 상품을 등록한 관리가 어떤 이유에서이든지
+    // 삭제 될 수 있기 때문에 nullable 입니다.
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "admin_id")
+    @JoinColumn(nullable = true, name = "admin_id")
     private Admin admin;
 
     public void updateInfo(String name, ItemCategory category, Long price) {

--- a/src/main/java/sparta/spartateamproject1/repository/ItemRepository.java
+++ b/src/main/java/sparta/spartateamproject1/repository/ItemRepository.java
@@ -1,7 +1,13 @@
 package sparta.spartateamproject1.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import sparta.spartateamproject1.entity.Item;
 
 public interface ItemRepository extends JpaRepository<Item,Long>, ItemRepositoryCustom {
+    @Modifying
+    @Query("UPDATE Item i SET i.admin = null WHERE i.admin.id = :adminId")
+    int setAdminToNullByAdminId(@Param("adminId") Long adminId);
 }

--- a/src/main/java/sparta/spartateamproject1/repository/ItemRepositoryCustomImpl.java
+++ b/src/main/java/sparta/spartateamproject1/repository/ItemRepositoryCustomImpl.java
@@ -43,7 +43,7 @@ public class ItemRepositoryCustomImpl implements ItemRepositoryCustom {
                 ))
                 .from(item)
                 .where(itemNameContains(dto), itemStatusEquals(dto), itemCategoryEquals(dto))
-                .innerJoin(admin)
+                .leftJoin(admin)
                 .on(item.admin.eq(admin))
                 .orderBy(getSortOrder(pageable))
                 .offset(pageable.getOffset())

--- a/src/main/java/sparta/spartateamproject1/service/impl/AdminServiceImpl.java
+++ b/src/main/java/sparta/spartateamproject1/service/impl/AdminServiceImpl.java
@@ -14,6 +14,7 @@ import sparta.spartateamproject1.exception.*;
 import sparta.spartateamproject1.repository.AdminRepository;
 import sparta.spartateamproject1.service.AdminService;
 import sparta.spartateamproject1.type.AdminStatus;
+import sparta.spartateamproject1.repository.ItemRepository;
 import sparta.spartateamproject1.type.ErrorCode;
 import sparta.spartateamproject1.type.Role;
 
@@ -26,6 +27,8 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class AdminServiceImpl implements AdminService {
     private final AdminRepository adminRepository;
+    private final ItemRepository itemRepository;
+
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
@@ -168,6 +171,10 @@ public class AdminServiceImpl implements AdminService {
         if(targetAdmin.getRole().equals(Role.SUPER_ADMIN)){
             throw new ForbiddenException("슈퍼관리자는 삭제할 수 없습니다.");
         }
+
+        // 이 admin이 등록한 상품들을 cleanup
+        itemRepository.setAdminToNullByAdminId(targetId);
+
         adminRepository.deleteById(targetId);
     }
 

--- a/src/main/java/sparta/spartateamproject1/service/impl/ItemServiceImpl.java
+++ b/src/main/java/sparta/spartateamproject1/service/impl/ItemServiceImpl.java
@@ -18,6 +18,8 @@ import sparta.spartateamproject1.exception.AdminNotFoundException;
 import sparta.spartateamproject1.exception.ForbiddenException;
 import sparta.spartateamproject1.exception.ItemNotFoundException;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -46,7 +48,7 @@ public class ItemServiceImpl implements ItemService {
 
         itemRepository.save(item);
 
-        return ItemGetDto.Response.fromEntity(item);
+        return ItemGetDto.Response.fromEntity(item, Optional.of(admin));
     }
 
     @Override
@@ -59,7 +61,10 @@ public class ItemServiceImpl implements ItemService {
         Item item = itemRepository.findById(id).orElseThrow(
             () -> new ItemNotFoundException("존재하지 않는 상품 입니다.")
         );
-        return ItemGetDto.Response.fromEntity(item);
+
+        Optional<Admin> registrar = getRegistrarSafe(item);
+
+        return ItemGetDto.Response.fromEntity(item, registrar);
     }
 
     @Override
@@ -149,5 +154,15 @@ public class ItemServiceImpl implements ItemService {
         }
 
         return admin;
+    }
+
+    private Optional<Admin> getRegistrarSafe(Item item) {
+        Admin admin = item.getAdmin();
+
+        if (admin == null) {
+            return Optional.empty();
+        }
+
+        return adminRepository.findById(item.getAdmin().getId());
     }
 }


### PR DESCRIPTION
지금까지는 상품을 등록한 관리자가 null이 될 수 없다는 전제하에 코드가 짜였었습니다.

하지만 관리자 삭제 될시 상품 까지 같이 삭제되는 것은 잘못됬다 생각하여 수정을 하였습니다.

이제 item 관련 코드들이 등록 관리자가 null인 경우에도 처리를 할 수 있고

또 관리자가 삭제 되었을 경우 자동으로 item의 admin을 null로 바꿉니다.