### PR TITLE
feat: json에서 DTO로 바꾸는 과정에서의 에러를 핸들링

### DIFF
--- a/src/main/java/sparta/spartateamproject1/exception/HttpMessageNotReadableExceptionHandler.java
+++ b/src/main/java/sparta/spartateamproject1/exception/HttpMessageNotReadableExceptionHandler.java
@@ -1,0 +1,64 @@
+package sparta.spartateamproject1.exception;
+
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+public class HttpMessageNotReadableExceptionHandler {
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<String> handleHttpMessageNotReadableException(
+            HttpMessageNotReadableException e
+    ) throws HttpMessageNotReadableException {
+        // 우리가 핸들링 할 수 있는게 아니므로 다시 spring 한테 넘김
+        if (!(e.getCause() instanceof InvalidFormatException formatException)) {
+            throw e;
+        }
+
+        var paths = formatException.getPath();
+
+        if (paths.isEmpty()) {
+            return ResponseEntity.badRequest()
+                .body(String.format("값 %s이(가) 잘못 되었습니다.", formatException.getValue()));
+        }
+
+        Class<?> clazz = formatException.getTargetType();
+
+        if (clazz.isEnum()) {
+            @SuppressWarnings("unchecked")
+            Class<? extends Enum<?>> enumClass = (Class<? extends Enum<?>>) formatException.getTargetType();
+            Enum<?>[] enumConstants = enumClass.getEnumConstants();
+
+            if (enumConstants.length <= 0) {
+                return ResponseEntity.badRequest()
+                    .body(String.format("값 %s이(가) 잘못 되었습니다.", formatException.getValue()));
+            }
+
+            StringBuilder sb = new StringBuilder();
+            sb.append(paths.get(0).getFieldName());
+            sb.append(": 값은 ");
+
+            for(int i=0; i<enumConstants.length; i++) {
+                Enum<?> constant = enumConstants[i];
+                sb.append(constant.name());
+
+                if (i != enumConstants.length-1) {
+                    sb.append(", ");
+                }
+            }
+
+            sb.append("중 하나여야 합니다.");
+
+            return ResponseEntity.badRequest().body(sb.toString());
+        }
+
+        return ResponseEntity.badRequest().body(String.format("%s: %s은(는) 잘못된 값입니다", 
+                paths.get(0).getFieldName(), formatException.getValue()));
+    }
+}


### PR DESCRIPTION
Spring이 json값을 dto로 옮기는 과정에서 에러가 날 경우 400을 던지는
대신에 더 칠절한 에러메세지를 보여줍니다.

<img width="318" height="254" alt="image" src="https://github.com/user-attachments/assets/f963570d-717f-4875-9d33-03c24669a7c9" />
