### PR TITLE
Refactor: 테스트 데이터 정리

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# secret.properties
+
+시작할 시 실행 폴더에 secret.properties라는 파일이 있을 경우 불러오도록 설정되어 있습니다.
+
+이곳에 비밀번호와 같이 민감한 설정이나 개인 설정을 추가 하실 수 있습니다.
+
+secret.properties 예시
+
+```
+# 실행시 테스트 관리자들을 추가
+app.add-test-admins=true
+# 실행시 테스트 상품들을 추가
+app.add-test-items=true
+# 실행시 테스트 고객들을 추가
+app.add-test-customers=true
+
+# 데이터베이스 설정
+spring.datasource.url=jdbc:mysql://localhost:3306/db
+spring.datasource.username=name
+spring.datasource.password=password
+spring.jpa.hibernate.ddl-auto=create
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+```
+
+# 테스트 데이터 추가
+
+개발 목적을 위해 테스트 데이터를 추가 할 수 있습니다.
+
+- app.add-test-admins=true : 테스트 관리자들을 추가합니다
+- app.add-test-items=true : 테스트 상품들을 추가합니다
+- app.add-test-customers=true : 테스트 고객들을 추가합니다.
+
+자세한 사항은 src/main/java/sparta/spartateamproject1/dev 폴더를 참고해 주세요.

--- a/src/main/java/sparta/spartateamproject1/dev/TestAdminAdder.java
+++ b/src/main/java/sparta/spartateamproject1/dev/TestAdminAdder.java
@@ -2,7 +2,6 @@ package sparta.spartateamproject1.dev;
 
 import java.time.LocalDateTime;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
@@ -11,31 +10,26 @@ import lombok.RequiredArgsConstructor;
 import sparta.spartateamproject1.config.PasswordEncoder;
 import sparta.spartateamproject1.entity.Admin;
 import sparta.spartateamproject1.entity.ApprovalResult;
-import sparta.spartateamproject1.entity.Customer;
 import sparta.spartateamproject1.repository.AdminRepository;
-import sparta.spartateamproject1.repository.CustomerRepository;
 import sparta.spartateamproject1.type.AdminStatus;
-import sparta.spartateamproject1.type.CustomerStatus;
 import sparta.spartateamproject1.type.Role;
 
 @Component
 @ConditionalOnProperty(
-    name = "app.add-test-super-admin",
+    name = "app.add-test-admins",
     havingValue = "true",
     matchIfMissing = false
 )
 @RequiredArgsConstructor
-public class TestSuperAdminAdder implements CommandLineRunner {
+public class TestAdminAdder implements CommandLineRunner {
     
     private final AdminRepository adminRepository;
 
     private final PasswordEncoder passwordEncoder;
-    private final CustomerRepository customerRepository;
 
     @Override
     public void run(String... args) throws Exception {
         ApprovalResult result = new ApprovalResult("", null, LocalDateTime.now(), true);
-//
 
         Admin superAdmin = Admin.builder()
             .name("super")
@@ -60,19 +54,5 @@ public class TestSuperAdminAdder implements CommandLineRunner {
                 .approvalResult(result)
                 .build();
         adminRepository.save(activeAdmin);
-
-        // 고객 데이터를 db에 저장해둠
-        for (int i = 1; i <= 30; i++) {
-            CustomerStatus cs;
-            if (i % 3 == 1) {
-                cs = CustomerStatus.ACTIVE;
-            } else if (i % 3 == 2) {
-                cs = CustomerStatus.INACTIVE;
-            } else {
-                cs = CustomerStatus.STOP;
-            }
-            Customer customer = new Customer("customer" + i, "customer" + i + "@gmail.com", "010-1234-1234", cs, LocalDateTime.now());
-            customerRepository.save(customer);
-        }
     }
 }

--- a/src/main/java/sparta/spartateamproject1/dev/TestCustomerAdder.java
+++ b/src/main/java/sparta/spartateamproject1/dev/TestCustomerAdder.java
@@ -1,0 +1,41 @@
+package sparta.spartateamproject1.dev;
+
+import java.time.LocalDateTime;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import sparta.spartateamproject1.entity.Customer;
+import sparta.spartateamproject1.repository.CustomerRepository;
+import sparta.spartateamproject1.type.CustomerStatus;
+
+@Component
+@ConditionalOnProperty(
+    name = "app.add-test-customers",
+    havingValue = "true",
+    matchIfMissing = false
+)
+@RequiredArgsConstructor
+public class TestCustomerAdder implements CommandLineRunner {
+    
+    private final CustomerRepository customerRepository;
+
+    @Override
+    public void run(String... args) throws Exception {
+        // 고객 데이터를 db에 저장해둠
+        for (int i = 1; i <= 30; i++) {
+            CustomerStatus cs;
+            if (i % 3 == 1) {
+                cs = CustomerStatus.ACTIVE;
+            } else if (i % 3 == 2) {
+                cs = CustomerStatus.INACTIVE;
+            } else {
+                cs = CustomerStatus.STOP;
+            }
+            Customer customer = new Customer("customer" + i, "customer" + i + "@gmail.com", "010-1234-1234", cs, LocalDateTime.now());
+            customerRepository.save(customer);
+        }
+    }
+}


### PR DESCRIPTION
살짝 섞여있던 테스트 데이터를 분리하였습니다.

이제

- app.add-test-admins는 테스트 관리자를 추가하고
- app.add-test-items는 테스트 상품을 추가하며
- app.add-test-customers는 테스트 고객들을 추가합니다

또 유지보수를 쉽게 하기 위해 README에 테스트 데이터를 추가하는 방법을 적었습니다.