### PR TITLE
fix: 상품 재고에따른 상태 수정 logic 보완

### DIFF
--- a/src/main/java/sparta/spartateamproject1/entity/Item.java
+++ b/src/main/java/sparta/spartateamproject1/entity/Item.java
@@ -59,12 +59,22 @@ public class Item {
     }
 
     public void updateStock(Long stock) {
+        Long previousStock = this.stock;
+
         this.stock = stock;
 
         // item상태가 단종이 아닐 경우 자동으로 업데이트 합니다.
         if (this.status != ItemStatus.DISCONTINUED) {
-            if (this.stock <= 0) {
-                this.status = ItemStatus.SOLD_OUT;
+            // 실제로 재고가 의미있게 변경 되었는지 확인
+            if (
+                (previousStock <= 0 && this.stock > 0) ||
+                (previousStock > 0 && this.stock <= 0)
+            ) {
+                if (this.stock <= 0) {
+                    this.status = ItemStatus.SOLD_OUT;
+                }else {
+                    this.status = ItemStatus.ON_SALE;
+                }
             }
         }
     }


### PR DESCRIPTION
전에는 상품 재고가 0일 경우 상품 재고를 0으로 수정한는 요청을 받았을시
상품 상태를 재고가 달리지지 않았음에도 수정하는 버그가 있었습니다.

이 commit은 그 버그를 해결합니다.